### PR TITLE
dont open stdin by default

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1,8 +1,9 @@
 #!/usr/bin/env node
 var bio = require('./')
+var argv = require('minimist')(process.argv.slice(2))
 var spawn = require('child_process').spawn
 
-var component = process.argv[2]
+var component = argv._[0]
 var path = __dirname + '/node_modules/bionode-' + component + '/cli.js'
 var args = process.argv.slice(3)
 var cli = spawn(path, args)
@@ -10,5 +11,8 @@ var cli = spawn(path, args)
 cli.stdout.pipe(process.stdout)
 cli.stderr.pipe(process.stderr)
 
-if (!process.stdin.isTTY) { process.stdin.pipe(cli.stdin) }
-else { cli.stdin.end() }
+if (argv._[argv._.length - 1] === '-') {
+  process.stdin.pipe(cli.stdin)
+} else {
+  cli.stdin.end()
+}

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "bionode-ncbi": "^0.8.2",
     "bionode-sam": "0.0.5",
     "bionode-seq": "^0.1.1",
-    "bionode-sra": "^0.2.5"
+    "bionode-sra": "^0.2.5",
+    "minimist": "^1.1.0"
   },
   "devDependencies": {
     "async": "^0.9.0",


### PR DESCRIPTION
this makes a breaking change I think

me and @mafintosh were trying to figure out why this was hanging:

```
bionode ncbi search genome eukaryota | dat import --json
```

and it was because of how bionode was always doing `process.stdin.pipe(cli.stdin)`. 

the more unixy way to do it would be to require a `-` as the last argument, which is what this implements, so now if you want bionode to read from stdin you can do:

```
bionode ncbi search genome eukaryota
```

otherwise it won't open stdin